### PR TITLE
feat: add USPCV port data

### DIFF
--- a/lib/ports.json
+++ b/lib/ports.json
@@ -25391,6 +25391,22 @@
       "USPCA"
     ]
   },
+  "USPCV": {
+    "name": "Port Canaveral",
+    "city": "Brevard County",
+    "province": "Florida",
+    "country": "United States",
+    "alias": [],
+    "regions": [],
+    "coordinates": [
+      -80.36,
+      28.24
+    ],
+    "timezone": "America/New_York",
+    "unlocs": [
+      "USPCV"
+    ]
+  },
   "USPDX": {
     "name": "Portland",
     "city": "Portland",


### PR DESCRIPTION
Add `Port Canaveral` port infos.

[Source](https://www.unece.org/fileadmin/DAM/cefact/locode/us.htm)